### PR TITLE
Implement Claude provider, LLM repair, and improved streaming parity

### DIFF
--- a/docs/llm-validation-retry.md
+++ b/docs/llm-validation-retry.md
@@ -1,0 +1,191 @@
+# LLM Validation and Retry
+
+Coevolved provides an "Instructor-style" pattern for structured output validation
+with automatic repair and retry when parsing or validation fails.
+
+## Quick Start
+
+```python
+from pydantic import BaseModel
+from coevolved.core import llm_step, LLMConfig
+from coevolved.prebuilt import llm_retry
+
+# Define your output schema
+class ExtractedUser(BaseModel):
+    name: str
+    age: int
+    email: str
+
+# Create a base LLM step
+llm = llm_step(
+    prompt_builder=lambda s: f"Extract user info from: {s['text']}",
+    provider=my_provider,
+    config=LLMConfig(model="gpt-4"),
+)
+
+# Wrap with validation and retry
+validated_llm = llm_retry(
+    llm,
+    output_schema=ExtractedUser,
+    max_attempts=3,
+)
+
+# Use it - validation failures automatically retry with repair context
+result = validated_llm({"text": "John Doe, 25 years old, john@example.com"})
+user = result["validated_output"]  # ExtractedUser instance
+```
+
+## Core Concepts
+
+### LLMRepairPolicy
+
+The `LLMRepairPolicy` configures retry behavior:
+
+```python
+from coevolved.core import LLMRepairPolicy
+
+policy = LLMRepairPolicy(
+    max_attempts=3,                    # Total attempts including initial
+    failure_to_input=my_repair_fn,     # Custom repair function
+    retryable_exceptions=(ValueError,), # Which exceptions trigger retry
+    backoff_seconds=0.5,               # Initial delay between retries
+    backoff_multiplier=2.0,            # Exponential backoff multiplier
+)
+```
+
+### Custom Repair Functions
+
+Repair functions receive context about the failure and return instructions
+for modifying the next attempt:
+
+```python
+from coevolved.core import RepairContext, RepairResult
+
+def custom_repair(ctx: RepairContext) -> RepairResult:
+    # ctx.error - The exception that occurred
+    # ctx.response - The LLM response that failed
+    # ctx.attempt - Current attempt number (1-indexed)
+    # ctx.state - Current state
+    
+    # Build a helpful error message
+    if "age" in str(ctx.error):
+        hint = "Age must be a positive integer, not a string."
+    else:
+        hint = f"Please fix: {ctx.error}"
+    
+    return RepairResult(
+        # Append messages to the conversation
+        messages_append=[{"role": "user", "content": hint}],
+        # Or update state
+        state_updates={"last_error": str(ctx.error)},
+    )
+
+validated_llm = llm_retry(
+    llm,
+    output_schema=ExtractedUser,
+    failure_to_input=custom_repair,
+)
+```
+
+### Custom Validators
+
+For non-Pydantic validation, provide a custom validator function:
+
+```python
+def validate_response(response: LLMResponse) -> dict:
+    """Custom validation logic."""
+    import json
+    
+    data = json.loads(response.text)
+    
+    # Custom validation rules
+    if data.get("score", 0) < 0:
+        raise ValueError("Score must be non-negative")
+    
+    if not data.get("summary"):
+        raise ValueError("Summary is required")
+    
+    return data
+
+validated_llm = llm_retry(
+    llm,
+    validator=validate_response,
+    max_attempts=3,
+)
+```
+
+## Agent Retry
+
+For higher-level agent retry (e.g., retrying an entire agent workflow):
+
+```python
+from coevolved.prebuilt import agent_retry, react_agent
+
+# Create an agent
+agent = react_agent(planner=planner, tools=tools, max_steps=10)
+
+# Wrap with retry logic
+reliable_agent = agent_retry(
+    agent,
+    max_attempts=3,
+    should_retry=lambda exc, state, attempt: isinstance(exc, TimeoutError),
+    on_retry=lambda exc, state, attempt: {**state, "retry_count": attempt},
+)
+
+result = reliable_agent(initial_state)
+```
+
+### Custom Retry Predicates
+
+Control which errors trigger retries:
+
+```python
+def should_retry(exc: Exception, state: Any, attempt: int) -> bool:
+    # Only retry on specific errors
+    if isinstance(exc, RateLimitError):
+        return True
+    if isinstance(exc, ValidationError) and attempt < 3:
+        return True
+    return False
+
+reliable_agent = agent_retry(agent, should_retry=should_retry)
+```
+
+### State Modification on Retry
+
+Modify state between retry attempts:
+
+```python
+def on_retry(exc: Exception, state: Any, attempt: int) -> dict:
+    # Reset certain state fields
+    return {
+        **state,
+        "tool_result": None,
+        "error_history": state.get("error_history", []) + [str(exc)],
+    }
+
+reliable_agent = agent_retry(agent, on_retry=on_retry)
+```
+
+## Tracing
+
+Validation attempts are traced via `LLMEvent` with events:
+- `validation_success` - When validation passes
+- `validation_failure` - When validation fails (before retry)
+
+These events include attempt metadata for debugging retry behavior.
+
+## Error Handling
+
+When all attempts are exhausted, `LLMValidationError` is raised:
+
+```python
+from coevolved.core import LLMValidationError
+
+try:
+    result = validated_llm(state)
+except LLMValidationError as e:
+    print(f"Failed after {e.attempts} attempts")
+    print(f"Last error: {e.last_error}")
+    print(f"Last response: {e.last_response.text}")
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,9 @@ dependencies = [
     "uuid_utils>=0.13.0",
 ]
 
+[project.optional-dependencies]
+anthropic = ["anthropic>=0.25.0"]
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/coevolved"]
 

--- a/src/coevolved/core/__init__.py
+++ b/src/coevolved/core/__init__.py
@@ -1,5 +1,15 @@
 from coevolved.core.llm import llm_step, tool_step
 from coevolved.core.llm_sequence import LLMSequence, llm_sequence
+from coevolved.core.llm_repair import (
+    DEFAULT_RETRYABLE_EXCEPTIONS,
+    LLMRepairPolicy,
+    LLMValidationError,
+    RepairContext,
+    RepairResult,
+    apply_repair_result,
+    default_validation_repair,
+    validated_llm_call,
+)
 from coevolved.core.prompt import Prompt, render_prompt
 from coevolved.core.events import LLMEvent, PromptEvent, ToolEvent
 from coevolved.core.types import (
@@ -15,7 +25,7 @@ from coevolved.core.types import (
 )
 from coevolved.core.tools import tool_spec_from_step, tool_specs_from_dict, tool_specs_from_steps
 from coevolved.core.formatters import DefaultLLMFormatter
-from coevolved.core.providers import OpenAIProvider
+from coevolved.core.providers import ClaudeProvider, OpenAIProvider
 
 __all__ = [
     # LLM step
@@ -24,6 +34,15 @@ __all__ = [
     # LLM sequence
     "LLMSequence",
     "llm_sequence",
+    # LLM repair/validation
+    "LLMRepairPolicy",
+    "LLMValidationError",
+    "RepairContext",
+    "RepairResult",
+    "DEFAULT_RETRYABLE_EXCEPTIONS",
+    "default_validation_repair",
+    "validated_llm_call",
+    "apply_repair_result",
     # Prompt
     "Prompt",
     "render_prompt",
@@ -48,5 +67,6 @@ __all__ = [
     # Formatters
     "DefaultLLMFormatter",
     # Providers
+    "ClaudeProvider",
     "OpenAIProvider",
 ]

--- a/src/coevolved/core/llm_repair.py
+++ b/src/coevolved/core/llm_repair.py
@@ -1,0 +1,376 @@
+"""LLM validation and repair infrastructure.
+
+This module provides the core abstraction for structured output validation
+with automatic repair/retry when parsing or validation fails. Inspired by
+the Instructor library's approach to reliable structured outputs.
+"""
+
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Optional, Tuple, Type, Union
+
+from pydantic import BaseModel, ValidationError
+
+from coevolved.base.step import Step
+from coevolved.base.tracing import get_current_invocation, get_default_tracer
+from coevolved.core.events import LLMEvent
+from coevolved.core.types import LLMResponse, PromptPayload
+
+
+class LLMValidationError(Exception):
+    """Raised when LLM output validation fails after all retry attempts.
+    
+    Attributes:
+        last_error: The final validation/parsing error that caused failure.
+        attempts: Number of attempts made before giving up.
+        last_response: The last LLM response received.
+    """
+    
+    def __init__(
+        self,
+        message: str,
+        *,
+        last_error: Exception,
+        attempts: int,
+        last_response: Optional[LLMResponse] = None,
+    ) -> None:
+        super().__init__(message)
+        self.last_error = last_error
+        self.attempts = attempts
+        self.last_response = last_response
+
+
+@dataclass
+class RepairContext:
+    """Context passed to failure_to_input for repair decisions.
+    
+    Attributes:
+        error: The exception that caused the failure (ValidationError, parsing error, etc.).
+        state: Current state being processed.
+        prompt_payload: The prompt payload that was sent to the LLM.
+        response: The LLM response that failed validation.
+        attempt: Current attempt number (1-indexed).
+        max_attempts: Maximum attempts configured.
+    """
+    error: Exception
+    state: Any
+    prompt_payload: PromptPayload
+    response: LLMResponse
+    attempt: int
+    max_attempts: int
+
+
+@dataclass
+class RepairResult:
+    """Result from a repair function specifying how to modify the next attempt.
+    
+    At least one of the fields should be set. If multiple are set, they are
+    applied in order: state updates, then prompt modifications.
+    
+    Attributes:
+        state_updates: Dictionary of updates to merge into state.
+        messages_append: Messages to append to the prompt messages list.
+        prompt_text_append: Text to append to prompt text.
+    """
+    state_updates: Optional[Dict[str, Any]] = None
+    messages_append: Optional[list] = None
+    prompt_text_append: Optional[str] = None
+
+
+FailureToInput = Callable[[RepairContext], RepairResult]
+"""Type alias for repair functions.
+
+A repair function receives context about the failure and returns
+a RepairResult specifying how to modify the next attempt.
+"""
+
+
+def default_validation_repair(ctx: RepairContext) -> RepairResult:
+    """Default repair function that appends validation errors to messages.
+    
+    For ValidationError, formats the error details in a structured way.
+    For other errors, includes the error message.
+    
+    Args:
+        ctx: Repair context with failure details.
+    
+    Returns:
+        RepairResult with error context appended as a user message.
+    """
+    if isinstance(ctx.error, ValidationError):
+        error_details = []
+        for err in ctx.error.errors():
+            loc = ".".join(str(x) for x in err["loc"]) if err["loc"] else "root"
+            error_details.append(f"- {loc}: {err['msg']}")
+        error_text = "\n".join(error_details)
+        repair_message = (
+            f"Your previous response failed validation. Please fix the following errors "
+            f"and try again:\n{error_text}\n\n"
+            f"Previous response that failed:\n{ctx.response.text or '[no text]'}"
+        )
+    else:
+        repair_message = (
+            f"Your previous response could not be parsed: {ctx.error}\n\n"
+            f"Please provide a valid response. Previous response:\n"
+            f"{ctx.response.text or '[no text]'}"
+        )
+    
+    return RepairResult(
+        messages_append=[{"role": "user", "content": repair_message}]
+    )
+
+
+DEFAULT_RETRYABLE_EXCEPTIONS: Tuple[Type[Exception], ...] = (
+    ValidationError,
+    ValueError,
+    TypeError,
+    KeyError,
+)
+"""Default exception types that trigger retry with repair."""
+
+
+@dataclass
+class LLMRepairPolicy:
+    """Policy for LLM validation and repair behavior.
+    
+    Configures how validation failures are handled, including retry limits,
+    repair strategies, and backoff behavior.
+    
+    Attributes:
+        max_attempts: Maximum number of attempts (including the initial attempt).
+        failure_to_input: Function that transforms failure into repair instructions.
+            Defaults to default_validation_repair which appends errors as messages.
+        retryable_exceptions: Tuple of exception types that should trigger retry.
+        backoff_seconds: Initial delay between retries (0 for no delay).
+        backoff_multiplier: Multiplier for exponential backoff.
+        include_response_in_repair: Whether to include the failed response text
+            in repair context (may be disabled for privacy).
+    
+    Example:
+        >>> policy = LLMRepairPolicy(
+        ...     max_attempts=3,
+        ...     failure_to_input=my_custom_repair,
+        ...     backoff_seconds=0.5,
+        ... )
+    """
+    max_attempts: int = 3
+    failure_to_input: FailureToInput = field(default=default_validation_repair)
+    retryable_exceptions: Tuple[Type[Exception], ...] = DEFAULT_RETRYABLE_EXCEPTIONS
+    backoff_seconds: float = 0.0
+    backoff_multiplier: float = 2.0
+    include_response_in_repair: bool = True
+
+    def is_retryable(self, exc: Exception) -> bool:
+        """Check if an exception should trigger a retry.
+        
+        Args:
+            exc: The exception to check.
+        
+        Returns:
+            True if the exception type is in retryable_exceptions.
+        """
+        return isinstance(exc, self.retryable_exceptions)
+
+
+@dataclass
+class ValidationAttemptEvent:
+    """Event data for a validation attempt (used in annotations).
+    
+    Attributes:
+        attempt: Attempt number (1-indexed).
+        max_attempts: Maximum attempts configured.
+        success: Whether this attempt succeeded.
+        error: Error message if failed.
+        elapsed_ms: Time taken for this attempt.
+    """
+    attempt: int
+    max_attempts: int
+    success: bool
+    error: Optional[str] = None
+    elapsed_ms: Optional[float] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary for event annotations."""
+        return {
+            "attempt": self.attempt,
+            "max_attempts": self.max_attempts,
+            "success": self.success,
+            "error": self.error,
+            "elapsed_ms": self.elapsed_ms,
+        }
+
+
+def apply_repair_result(
+    state: Any,
+    prompt_payload: PromptPayload,
+    repair: RepairResult,
+) -> Tuple[Any, PromptPayload]:
+    """Apply a RepairResult to state and prompt payload.
+    
+    Args:
+        state: Current state.
+        prompt_payload: Current prompt payload.
+        repair: Repair result to apply.
+    
+    Returns:
+        Tuple of (updated_state, updated_prompt_payload).
+    """
+    new_state = state
+    new_payload = prompt_payload
+    
+    if repair.state_updates:
+        if isinstance(state, dict):
+            new_state = {**state, **repair.state_updates}
+        elif isinstance(state, BaseModel):
+            new_state = state.model_copy(update=repair.state_updates)
+        else:
+            for k, v in repair.state_updates.items():
+                setattr(new_state, k, v)
+    
+    if repair.messages_append and new_payload.messages is not None:
+        new_messages = list(new_payload.messages) + repair.messages_append
+        new_payload = new_payload.model_copy(update={"messages": new_messages})
+    elif repair.messages_append and new_payload.messages is None:
+        if new_payload.text:
+            initial_messages = [{"role": "user", "content": new_payload.text}]
+            new_messages = initial_messages + repair.messages_append
+            new_payload = new_payload.model_copy(
+                update={"messages": new_messages, "text": None}
+            )
+    
+    if repair.prompt_text_append and new_payload.text is not None:
+        new_text = new_payload.text + "\n\n" + repair.prompt_text_append
+        new_payload = new_payload.model_copy(update={"text": new_text})
+    
+    return new_state, new_payload
+
+
+def validated_llm_call(
+    *,
+    llm_fn: Callable[[Any, PromptPayload], LLMResponse],
+    prompt_payload: PromptPayload,
+    state: Any,
+    validator: Callable[[LLMResponse], Any],
+    policy: LLMRepairPolicy,
+    step_name: str = "validated_llm",
+) -> Any:
+    """Execute an LLM call with validation and automatic repair/retry.
+    
+    This is the core function that implements the validation loop. It:
+    1. Calls the LLM
+    2. Validates the response
+    3. On validation failure, applies repair and retries
+    4. Returns the validated output or raises LLMValidationError
+    
+    Args:
+        llm_fn: Function that executes the LLM call. Signature: (state, payload) -> LLMResponse
+        prompt_payload: Initial prompt payload.
+        state: Current state.
+        validator: Function that validates LLMResponse and returns parsed output.
+            Should raise an exception (typically ValidationError) on failure.
+        policy: Repair policy configuration.
+        step_name: Name for tracing purposes.
+    
+    Returns:
+        Validated and parsed output from the validator function.
+    
+    Raises:
+        LLMValidationError: If validation fails after all attempts.
+    """
+    tracer = get_default_tracer()
+    invocation_ctx = get_current_invocation()
+    
+    current_state = state
+    current_payload = prompt_payload
+    last_error: Optional[Exception] = None
+    last_response: Optional[LLMResponse] = None
+    delay = policy.backoff_seconds
+    
+    for attempt in range(1, policy.max_attempts + 1):
+        attempt_start = time.perf_counter()
+        
+        try:
+            response = llm_fn(current_state, current_payload)
+            last_response = response
+            
+            result = validator(response)
+            
+            if invocation_ctx:
+                attempt_event = ValidationAttemptEvent(
+                    attempt=attempt,
+                    max_attempts=policy.max_attempts,
+                    success=True,
+                    elapsed_ms=(time.perf_counter() - attempt_start) * 1000,
+                )
+                tracer.emit(
+                    LLMEvent(
+                        run_id=invocation_ctx.run_id,
+                        step_id=invocation_ctx.step_id,
+                        invocation_id=invocation_ctx.invocation_id,
+                        group_hash=invocation_ctx.group_hash,
+                        step_name=step_name,
+                        event="validation_success",
+                        timestamp=time.time(),
+                        text=response.text,
+                        finish_reason=response.finish_reason,
+                        model=response.model,
+                        usage=response.usage,
+                    )
+                )
+            
+            return result
+            
+        except policy.retryable_exceptions as exc:
+            last_error = exc
+            elapsed_ms = (time.perf_counter() - attempt_start) * 1000
+            
+            if invocation_ctx:
+                attempt_event = ValidationAttemptEvent(
+                    attempt=attempt,
+                    max_attempts=policy.max_attempts,
+                    success=False,
+                    error=str(exc),
+                    elapsed_ms=elapsed_ms,
+                )
+                tracer.emit(
+                    LLMEvent(
+                        run_id=invocation_ctx.run_id,
+                        step_id=invocation_ctx.step_id,
+                        invocation_id=invocation_ctx.invocation_id,
+                        group_hash=invocation_ctx.group_hash,
+                        step_name=step_name,
+                        event="validation_failure",
+                        timestamp=time.time(),
+                        text=last_response.text if last_response else None,
+                        finish_reason=last_response.finish_reason if last_response else None,
+                        model=last_response.model if last_response else None,
+                    )
+                )
+            
+            if attempt >= policy.max_attempts:
+                break
+            
+            repair_ctx = RepairContext(
+                error=exc,
+                state=current_state,
+                prompt_payload=current_payload,
+                response=last_response or LLMResponse(),
+                attempt=attempt,
+                max_attempts=policy.max_attempts,
+            )
+            
+            repair_result = policy.failure_to_input(repair_ctx)
+            current_state, current_payload = apply_repair_result(
+                current_state, current_payload, repair_result
+            )
+            
+            if delay > 0:
+                time.sleep(delay)
+                delay *= policy.backoff_multiplier
+    
+    raise LLMValidationError(
+        f"Validation failed after {policy.max_attempts} attempts: {last_error}",
+        last_error=last_error or ValueError("Unknown error"),
+        attempts=policy.max_attempts,
+        last_response=last_response,
+    )

--- a/src/coevolved/core/providers/__init__.py
+++ b/src/coevolved/core/providers/__init__.py
@@ -1,3 +1,4 @@
+from coevolved.core.providers.claude import ClaudeProvider
 from coevolved.core.providers.openai import OpenAIProvider
 
-__all__ = ["OpenAIProvider"]
+__all__ = ["ClaudeProvider", "OpenAIProvider"]

--- a/src/coevolved/core/providers/claude.py
+++ b/src/coevolved/core/providers/claude.py
@@ -1,0 +1,297 @@
+"""Claude (Anthropic) provider implementation for LLM requests.
+
+This module provides a ClaudeProvider that implements both LLMProvider and
+StreamingLLMProvider protocols for use with Anthropic's API client.
+"""
+
+import json
+from typing import Any, Dict, Iterator, List, Optional, Tuple
+
+from coevolved.core.types import (
+    LLMRequest,
+    LLMResponse,
+    LLMStreamChunk,
+    PromptPayload,
+    ToolCall,
+    ToolSpec,
+)
+
+
+class ClaudeProvider:
+    """LLM provider implementation for Anthropic's Claude API.
+
+    Implements both LLMProvider and StreamingLLMProvider protocols.
+
+    Args:
+        client: Anthropic client instance (from anthropic.Anthropic()).
+        request_options: Optional default request options to merge with each request.
+    """
+
+    def __init__(self, client: Any, *, request_options: Optional[Dict[str, Any]] = None) -> None:
+        self.client = client
+        self.request_options = request_options or {}
+
+    def complete(self, request: LLMRequest) -> LLMResponse:
+        """Execute an LLM request using Anthropic's API."""
+        params = self._build_params(request)
+        response = self.client.messages.create(**params)
+        return self._parse_response(response)
+
+    def stream(self, request: LLMRequest) -> Iterator[LLMStreamChunk]:
+        """Stream an LLM response chunk by chunk."""
+        params = self._build_params(request)
+        params["stream"] = True
+
+        response_stream = self.client.messages.create(**params)
+
+        if hasattr(response_stream, "__enter__"):
+            with response_stream as stream:
+                yield from self._stream_events(stream)
+            return
+
+        yield from self._stream_events(response_stream)
+
+    def _build_params(self, request: LLMRequest) -> Dict[str, Any]:
+        """Build parameters for Anthropic API call."""
+        messages, system = _coerce_messages(request.prompt)
+        tools = _claude_tool_specs(request.context.tools)
+        tool_choice = request.context.tool_choice
+
+        if tool_choice == "none":
+            tools = []
+            tool_choice = None
+
+        params: Dict[str, Any] = {
+            "model": request.context.model,
+            "messages": messages,
+        }
+        if system:
+            params["system"] = system
+        if tools:
+            params["tools"] = tools
+            tool_choice_param = _claude_tool_choice(tool_choice)
+            if tool_choice_param:
+                params["tool_choice"] = tool_choice_param
+
+        if request.context.temperature is not None:
+            params["temperature"] = request.context.temperature
+
+        if request.context.max_tokens is not None:
+            params["max_tokens"] = request.context.max_tokens
+
+        request_options = dict(self.request_options)
+        extra_options = request.context.metadata.get("request_options")
+        if isinstance(extra_options, dict):
+            request_options.update(extra_options)
+        params.update(request_options)
+
+        return params
+
+    def _parse_response(self, response: Any) -> LLMResponse:
+        """Parse Anthropic response into LLMResponse."""
+        tool_calls: List[ToolCall] = []
+        text_parts: List[str] = []
+
+        for block in getattr(response, "content", []) or []:
+            block_type = _get_attr(block, "type")
+            if block_type == "text":
+                text = _get_attr(block, "text")
+                if text:
+                    text_parts.append(str(text))
+            elif block_type == "tool_use":
+                tool_calls.append(
+                    ToolCall(
+                        id=_get_attr(block, "id"),
+                        name=_get_attr(block, "name"),
+                        arguments=_parse_arguments(_get_attr(block, "input")),
+                    )
+                )
+
+        usage = _usage_dict(getattr(response, "usage", None))
+
+        return LLMResponse(
+            text="".join(text_parts) if text_parts else None,
+            tool_calls=tool_calls,
+            raw=response,
+            model=_get_attr(response, "model"),
+            finish_reason=_get_attr(response, "stop_reason"),
+            usage=usage,
+        )
+
+    def _stream_events(self, stream: Iterator[Any]) -> Iterator[LLMStreamChunk]:
+        tool_calls_builder: Dict[int, Dict[str, Any]] = {}
+        finish_reason: Optional[str] = None
+        pending_usage: Optional[Dict[str, Any]] = None
+        finish_emitted = False
+
+        for event in stream:
+            event_type = _get_attr(event, "type")
+
+            if event_type == "message_start":
+                message = _get_attr(event, "message")
+                usage = _usage_dict(_get_attr(message, "usage"))
+                if usage:
+                    pending_usage = usage
+                continue
+
+            if event_type == "content_block_start":
+                block = _get_attr(event, "content_block")
+                block_type = _get_attr(block, "type")
+                if block_type == "tool_use":
+                    idx = _get_attr(event, "index") or 0
+                    tool_calls_builder[idx] = {
+                        "id": _get_attr(block, "id"),
+                        "name": _get_attr(block, "name"),
+                        "arguments": "",
+                    }
+                    yield LLMStreamChunk(
+                        tool_call_delta={
+                            "index": idx,
+                            "id": _get_attr(block, "id"),
+                            "name": _get_attr(block, "name"),
+                            "arguments_delta": "",
+                        }
+                    )
+                continue
+
+            if event_type == "content_block_delta":
+                delta = _get_attr(event, "delta")
+                delta_type = _get_attr(delta, "type")
+
+                if delta_type == "text_delta":
+                    text = _get_attr(delta, "text")
+                    if text:
+                        yield LLMStreamChunk(text=str(text))
+                    continue
+
+                if delta_type == "input_json_delta":
+                    idx = _get_attr(event, "index") or 0
+                    partial = _get_attr(delta, "partial_json")
+                    if partial is None:
+                        partial = _get_attr(delta, "text")
+                    tool_call = tool_calls_builder.setdefault(
+                        idx,
+                        {"id": None, "name": None, "arguments": ""},
+                    )
+                    if partial:
+                        tool_call["arguments"] += str(partial)
+                    yield LLMStreamChunk(
+                        tool_call_delta={
+                            "index": idx,
+                            "id": tool_call.get("id"),
+                            "name": tool_call.get("name"),
+                            "arguments_delta": partial,
+                        }
+                    )
+                continue
+
+            if event_type == "message_delta":
+                delta = _get_attr(event, "delta")
+                stop_reason = _get_attr(delta, "stop_reason")
+                if stop_reason:
+                    finish_reason = stop_reason
+                usage = _usage_dict(_get_attr(delta, "usage"))
+                if usage:
+                    pending_usage = usage
+                continue
+
+            if event_type == "message_stop":
+                stop_reason = _get_attr(_get_attr(event, "message"), "stop_reason")
+                finish_reason = stop_reason or finish_reason
+                yield LLMStreamChunk(finish_reason=finish_reason, usage=pending_usage)
+                finish_emitted = True
+                continue
+
+        if not finish_emitted and (finish_reason or pending_usage):
+            yield LLMStreamChunk(finish_reason=finish_reason, usage=pending_usage)
+
+
+def _parse_arguments(value: Any) -> Dict[str, Any]:
+    """Parse tool call arguments from string or dict."""
+    if value is None:
+        return {}
+    if isinstance(value, dict):
+        return value
+    try:
+        return json.loads(str(value))
+    except Exception:
+        return {}
+
+
+def _claude_tool_specs(tools: List[ToolSpec]) -> List[Dict[str, Any]]:
+    """Convert ToolSpec list to Claude tool format."""
+    specs: List[Dict[str, Any]] = []
+    for tool in tools:
+        specs.append(
+            {
+                "name": tool.name,
+                "description": tool.description or "Tool call.",
+                "input_schema": tool.parameters,
+            }
+        )
+    return specs
+
+
+def _claude_tool_choice(value: Optional[str]) -> Optional[Dict[str, Any]]:
+    """Normalize tool_choice for Claude API."""
+    if value is None:
+        return None
+    if value == "auto":
+        return {"type": "auto"}
+    return {"type": "tool", "name": value}
+
+
+def _coerce_messages(prompt: PromptPayload) -> Tuple[List[Dict[str, Any]], Optional[str]]:
+    """Convert PromptPayload to Claude messages format."""
+    if prompt.messages is not None:
+        system_parts: List[str] = []
+        messages: List[Dict[str, Any]] = []
+        for message in prompt.messages:
+            role = message.get("role")
+            content = message.get("content")
+            if role == "system":
+                if content is not None:
+                    system_parts.append(_content_to_text(content))
+                continue
+            if role not in {"user", "assistant"}:
+                role = "user"
+            messages.append({"role": role, "content": content})
+        return messages, "\n\n".join(part for part in system_parts if part) or None
+    if prompt.text is not None:
+        return [{"role": "user", "content": prompt.text}], None
+    raise ValueError("PromptPayload must include text or messages.")
+
+
+def _content_to_text(content: Any) -> str:
+    """Normalize message content to text for system prompts."""
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return "".join(
+            str(item.get("text", "")) if isinstance(item, dict) else str(item) for item in content
+        )
+    if isinstance(content, dict):
+        return str(content.get("text", content))
+    return str(content)
+
+
+def _get_attr(obj: Any, name: str) -> Any:
+    """Get attribute from dict-like or object."""
+    if obj is None:
+        return None
+    if isinstance(obj, dict):
+        return obj.get(name)
+    return getattr(obj, name, None)
+
+
+def _usage_dict(usage: Any) -> Optional[Dict[str, Any]]:
+    """Convert usage object to dict."""
+    if usage is None:
+        return None
+    if hasattr(usage, "model_dump"):
+        return usage.model_dump()
+    if isinstance(usage, dict):
+        return usage
+    return {"value": str(usage)}

--- a/src/coevolved/prebuilt/__init__.py
+++ b/src/coevolved/prebuilt/__init__.py
@@ -6,6 +6,7 @@ from coevolved.prebuilt.context import (
 )
 from coevolved.prebuilt.events import AgentEvent
 from coevolved.prebuilt.formatters import DefaultAgentFormatter
+from coevolved.prebuilt.llm_retry import agent_retry, llm_retry
 from coevolved.prebuilt.loop import (
     LoopPolicy,
     LoopState,
@@ -22,6 +23,9 @@ __all__ = [
     "simple_loop",
     "LoopPolicy",
     "LoopState",
+    # LLM and agent retry
+    "llm_retry",
+    "agent_retry",
     # Events and context
     "AgentEvent",
     "AgentContext",

--- a/src/coevolved/prebuilt/llm_retry.py
+++ b/src/coevolved/prebuilt/llm_retry.py
@@ -1,0 +1,388 @@
+"""LLM and agent retry utilities.
+
+This module provides prebuilt helpers for wrapping LLM steps and agents
+with validation, repair, and retry behavior.
+"""
+
+import time
+from typing import Any, Callable, Dict, Optional, Tuple, Type, Union
+
+from pydantic import BaseModel, ValidationError
+
+from coevolved.base.step import Step
+from coevolved.base.tracing import get_default_tracer
+from coevolved.core.llm_repair import (
+    DEFAULT_RETRYABLE_EXCEPTIONS,
+    LLMRepairPolicy,
+    LLMValidationError,
+    RepairContext,
+    RepairResult,
+    apply_repair_result,
+    default_validation_repair,
+    validated_llm_call,
+)
+from coevolved.core.types import LLMResponse, PromptPayload
+
+
+def llm_retry(
+    step: Step,
+    *,
+    output_schema: Optional[Type[BaseModel]] = None,
+    validator: Optional[Callable[[LLMResponse], Any]] = None,
+    repair_policy: Optional[LLMRepairPolicy] = None,
+    max_attempts: int = 3,
+    failure_to_input: Optional[Callable[[RepairContext], RepairResult]] = None,
+    result_key: Optional[str] = "validated_output",
+) -> Step:
+    """Wrap an LLM step with validation and automatic repair/retry.
+    
+    This creates a new Step that executes the original LLM step, validates
+    the output, and retries with repair context if validation fails.
+    
+    The validation can be specified either via:
+    - output_schema: A Pydantic model to validate against (parses response.text as JSON)
+    - validator: A custom function that validates LLMResponse and returns parsed output
+    
+    If neither is provided, the step will just retry on any exception from the
+    original step's parser.
+    
+    Args:
+        step: The LLM step to wrap. Must be created with llm_step().
+        output_schema: Optional Pydantic model for output validation.
+            If provided, response.text is parsed as JSON and validated.
+        validator: Optional custom validator function.
+            Signature: (LLMResponse) -> Any. Should raise on validation failure.
+        repair_policy: Full repair policy configuration. If provided, overrides
+            max_attempts and failure_to_input.
+        max_attempts: Maximum number of attempts (default: 3).
+        failure_to_input: Custom repair function. Defaults to default_validation_repair.
+        result_key: Key to attach validated result in state. If None, returns
+            result directly. Defaults to "validated_output".
+    
+    Returns:
+        Step that executes the LLM call with validation and retry.
+    
+    Raises:
+        LLMValidationError: If validation fails after all attempts.
+        ValueError: If step is not an LLM step.
+    
+    Example:
+        >>> from pydantic import BaseModel
+        >>> 
+        >>> class ExtractedData(BaseModel):
+        ...     name: str
+        ...     age: int
+        >>> 
+        >>> # Create base LLM step
+        >>> llm = llm_step(
+        ...     prompt_builder=lambda s: f"Extract: {s['text']}",
+        ...     provider=provider,
+        ...     config=config,
+        ... )
+        >>> 
+        >>> # Wrap with validation and retry
+        >>> validated_llm = llm_retry(
+        ...     llm,
+        ...     output_schema=ExtractedData,
+        ...     max_attempts=3,
+        ... )
+        >>> 
+        >>> result = validated_llm({"text": "John is 25 years old"})
+        >>> # result["validated_output"] is ExtractedData(name="John", age=25)
+    
+    Example with custom validator:
+        >>> def validate_and_parse(response: LLMResponse) -> dict:
+        ...     data = json.loads(response.text)
+        ...     if "error" in data:
+        ...         raise ValueError(f"LLM returned error: {data['error']}")
+        ...     return data
+        >>> 
+        >>> validated_llm = llm_retry(
+        ...     llm,
+        ...     validator=validate_and_parse,
+        ...     max_attempts=2,
+        ... )
+    
+    Example with custom repair:
+        >>> def my_repair(ctx: RepairContext) -> RepairResult:
+        ...     # Add specific guidance based on error type
+        ...     if "age" in str(ctx.error):
+        ...         hint = "Age must be a positive integer."
+        ...     else:
+        ...         hint = "Please fix the errors and try again."
+        ...     return RepairResult(
+        ...         messages_append=[{"role": "user", "content": hint}]
+        ...     )
+        >>> 
+        >>> validated_llm = llm_retry(
+        ...     llm,
+        ...     output_schema=ExtractedData,
+        ...     failure_to_input=my_repair,
+        ... )
+    """
+    if step.annotations.get("kind") != "llm":
+        raise ValueError("llm_retry requires an LLM step created with llm_step().")
+    
+    policy = repair_policy or LLMRepairPolicy(
+        max_attempts=max_attempts,
+        failure_to_input=failure_to_input or default_validation_repair,
+    )
+    
+    actual_validator = _build_validator(output_schema, validator)
+    
+    def run(state: Any) -> Any:
+        last_error: Optional[Exception] = None
+        last_response: Optional[LLMResponse] = None
+        current_state = state
+        delay = policy.backoff_seconds
+        
+        for attempt in range(1, policy.max_attempts + 1):
+            try:
+                result_state = step(current_state)
+                
+                llm_response_key = step.annotations.get("result_key", "llm_response")
+                if isinstance(result_state, dict):
+                    response = result_state.get(llm_response_key)
+                elif isinstance(result_state, BaseModel):
+                    response = getattr(result_state, llm_response_key, None)
+                else:
+                    response = getattr(result_state, llm_response_key, None)
+                
+                if response is None:
+                    response = result_state
+                
+                if not isinstance(response, LLMResponse):
+                    if isinstance(response, dict):
+                        response = LLMResponse.model_validate(response)
+                    else:
+                        response = LLMResponse(text=str(response))
+                
+                last_response = response
+                validated = actual_validator(response)
+                
+                if result_key is None:
+                    return validated
+                if isinstance(result_state, dict):
+                    return {**result_state, result_key: validated}
+                if isinstance(result_state, BaseModel):
+                    return result_state.model_copy(update={result_key: validated})
+                return validated
+                
+            except policy.retryable_exceptions as exc:
+                last_error = exc
+                
+                if attempt >= policy.max_attempts:
+                    break
+                
+                repair_ctx = RepairContext(
+                    error=exc,
+                    state=current_state,
+                    prompt_payload=PromptPayload(),
+                    response=last_response or LLMResponse(),
+                    attempt=attempt,
+                    max_attempts=policy.max_attempts,
+                )
+                
+                repair_result = policy.failure_to_input(repair_ctx)
+                
+                if repair_result.state_updates:
+                    if isinstance(current_state, dict):
+                        current_state = {**current_state, **repair_result.state_updates}
+                    elif isinstance(current_state, BaseModel):
+                        current_state = current_state.model_copy(
+                            update=repair_result.state_updates
+                        )
+                
+                if repair_result.messages_append:
+                    messages_key = "messages"
+                    if isinstance(current_state, dict):
+                        existing = current_state.get(messages_key, [])
+                        current_state = {
+                            **current_state,
+                            messages_key: list(existing) + repair_result.messages_append,
+                        }
+                    elif isinstance(current_state, BaseModel):
+                        existing = getattr(current_state, messages_key, []) or []
+                        current_state = current_state.model_copy(
+                            update={messages_key: list(existing) + repair_result.messages_append}
+                        )
+                
+                if delay > 0:
+                    time.sleep(delay)
+                    delay *= policy.backoff_multiplier
+        
+        raise LLMValidationError(
+            f"Validation failed after {policy.max_attempts} attempts: {last_error}",
+            last_error=last_error or ValueError("Unknown error"),
+            attempts=policy.max_attempts,
+            last_response=last_response,
+        )
+    
+    return Step(
+        run,
+        name=f"{step.name}_retry",
+        input_schema=step.input_schema,
+        output_schema=step.output_schema,
+        annotations={
+            **step.annotations,
+            "retry_wrapper": True,
+            "max_attempts": policy.max_attempts,
+        },
+    )
+
+
+def _build_validator(
+    output_schema: Optional[Type[BaseModel]],
+    validator: Optional[Callable[[LLMResponse], Any]],
+) -> Callable[[LLMResponse], Any]:
+    """Build the validator function from schema or custom validator."""
+    if validator is not None:
+        return validator
+    
+    if output_schema is not None:
+        import json
+        
+        def schema_validator(response: LLMResponse) -> BaseModel:
+            if response.text is None:
+                raise ValueError("LLM response has no text to parse")
+            
+            text = response.text.strip()
+            if text.startswith("```json"):
+                text = text[7:]
+            if text.startswith("```"):
+                text = text[3:]
+            if text.endswith("```"):
+                text = text[:-3]
+            text = text.strip()
+            
+            try:
+                data = json.loads(text)
+            except json.JSONDecodeError as e:
+                raise ValueError(f"Failed to parse JSON: {e}") from e
+            
+            return output_schema.model_validate(data)
+        
+        return schema_validator
+    
+    def passthrough(response: LLMResponse) -> LLMResponse:
+        return response
+    
+    return passthrough
+
+
+ShouldRetry = Callable[[Exception, Any, int], bool]
+"""Type alias for retry predicate functions.
+
+Signature: (exception, state, attempt) -> should_retry
+"""
+
+
+def default_should_retry(exc: Exception, state: Any, attempt: int) -> bool:
+    """Default retry predicate that retries on common retryable exceptions."""
+    return isinstance(exc, DEFAULT_RETRYABLE_EXCEPTIONS)
+
+
+def agent_retry(
+    step: Step,
+    *,
+    max_attempts: int = 3,
+    should_retry: Optional[ShouldRetry] = None,
+    backoff_seconds: float = 0.0,
+    backoff_multiplier: float = 2.0,
+    on_retry: Optional[Callable[[Exception, Any, int], Any]] = None,
+) -> Step:
+    """Wrap a step or agent with bounded retry logic.
+    
+    This is a higher-level retry wrapper suitable for agent workflows.
+    Unlike llm_retry which focuses on LLM output validation, agent_retry
+    provides general-purpose retry with customizable predicates.
+    
+    Args:
+        step: The step or agent to wrap.
+        max_attempts: Maximum number of attempts (default: 3).
+        should_retry: Predicate function to determine if an exception should
+            trigger a retry. Signature: (exc, state, attempt) -> bool.
+            Defaults to retrying on ValidationError and common parsing errors.
+        backoff_seconds: Initial delay between retries (default: 0).
+        backoff_multiplier: Multiplier for exponential backoff (default: 2.0).
+        on_retry: Optional callback invoked before each retry.
+            Signature: (exc, state, attempt) -> new_state.
+            Can be used to modify state between retries. If it returns a value,
+            that becomes the new state for the retry.
+    
+    Returns:
+        Step that executes with retry logic.
+    
+    Raises:
+        Exception: The last exception if all attempts fail.
+    
+    Example:
+        >>> agent = react_agent(planner=planner, tools=tools)
+        >>> 
+        >>> # Retry the agent up to 3 times on failure
+        >>> reliable_agent = agent_retry(agent, max_attempts=3)
+        >>> result = reliable_agent(initial_state)
+    
+    Example with custom retry predicate:
+        >>> def retry_on_timeout(exc, state, attempt):
+        ...     return isinstance(exc, TimeoutError) and attempt < 5
+        >>> 
+        >>> reliable_agent = agent_retry(
+        ...     agent,
+        ...     should_retry=retry_on_timeout,
+        ...     backoff_seconds=1.0,
+        ... )
+    
+    Example with state modification on retry:
+        >>> def reset_on_retry(exc, state, attempt):
+        ...     # Clear tool results and try again
+        ...     return {**state, "tool_result": None, "retry_count": attempt}
+        >>> 
+        >>> reliable_agent = agent_retry(
+        ...     agent,
+        ...     on_retry=reset_on_retry,
+        ... )
+    """
+    retry_predicate = should_retry or default_should_retry
+    
+    def run(state: Any) -> Any:
+        current_state = state
+        delay = backoff_seconds
+        last_error: Optional[Exception] = None
+        
+        for attempt in range(1, max_attempts + 1):
+            try:
+                return step(current_state)
+            except Exception as exc:
+                last_error = exc
+                
+                if attempt >= max_attempts:
+                    raise
+                
+                if not retry_predicate(exc, current_state, attempt):
+                    raise
+                
+                if on_retry is not None:
+                    modified = on_retry(exc, current_state, attempt)
+                    if modified is not None:
+                        current_state = modified
+                
+                if delay > 0:
+                    time.sleep(delay)
+                    delay *= backoff_multiplier
+        
+        if last_error:
+            raise last_error
+        return current_state
+    
+    return Step(
+        run,
+        name=f"{step.name}_retry",
+        input_schema=step.input_schema,
+        output_schema=step.output_schema,
+        annotations={
+            **step.annotations,
+            "agent_retry_wrapper": True,
+            "max_attempts": max_attempts,
+        },
+    )

--- a/tests/core/llm_repair/test_llm_repair.py
+++ b/tests/core/llm_repair/test_llm_repair.py
@@ -1,0 +1,326 @@
+"""Tests for LLM validation and repair infrastructure."""
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from coevolved.core.llm_repair import (
+    DEFAULT_RETRYABLE_EXCEPTIONS,
+    LLMRepairPolicy,
+    LLMValidationError,
+    RepairContext,
+    RepairResult,
+    apply_repair_result,
+    default_validation_repair,
+    validated_llm_call,
+)
+from coevolved.core.types import LLMResponse, PromptPayload
+
+
+class ExtractedUser(BaseModel):
+    name: str
+    age: int
+
+
+class TestRepairContext:
+    def test_repair_context_holds_all_fields(self):
+        error = ValueError("test error")
+        ctx = RepairContext(
+            error=error,
+            state={"key": "value"},
+            prompt_payload=PromptPayload(text="test"),
+            response=LLMResponse(text="bad response"),
+            attempt=1,
+            max_attempts=3,
+        )
+        assert ctx.error is error
+        assert ctx.state == {"key": "value"}
+        assert ctx.prompt_payload.text == "test"
+        assert ctx.response.text == "bad response"
+        assert ctx.attempt == 1
+        assert ctx.max_attempts == 3
+
+
+class TestRepairResult:
+    def test_apply_repair_result_with_state_updates_dict(self):
+        state = {"a": 1, "b": 2}
+        payload = PromptPayload(text="test")
+        repair = RepairResult(state_updates={"b": 3, "c": 4})
+        
+        new_state, new_payload = apply_repair_result(state, payload, repair)
+        
+        assert new_state == {"a": 1, "b": 3, "c": 4}
+        assert new_payload is payload
+
+    def test_apply_repair_result_with_state_updates_pydantic(self):
+        class State(BaseModel):
+            a: int
+            b: int = 0
+        
+        state = State(a=1, b=2)
+        payload = PromptPayload(text="test")
+        repair = RepairResult(state_updates={"b": 5})
+        
+        new_state, new_payload = apply_repair_result(state, payload, repair)
+        
+        assert new_state.a == 1
+        assert new_state.b == 5
+
+    def test_apply_repair_result_with_messages_append(self):
+        state = {}
+        payload = PromptPayload(messages=[{"role": "user", "content": "hello"}])
+        repair = RepairResult(
+            messages_append=[{"role": "user", "content": "fix this"}]
+        )
+        
+        new_state, new_payload = apply_repair_result(state, payload, repair)
+        
+        assert len(new_payload.messages) == 2
+        assert new_payload.messages[1]["content"] == "fix this"
+
+    def test_apply_repair_result_converts_text_to_messages(self):
+        state = {}
+        payload = PromptPayload(text="initial prompt")
+        repair = RepairResult(
+            messages_append=[{"role": "user", "content": "repair context"}]
+        )
+        
+        new_state, new_payload = apply_repair_result(state, payload, repair)
+        
+        assert new_payload.messages is not None
+        assert len(new_payload.messages) == 2
+        assert new_payload.messages[0]["content"] == "initial prompt"
+        assert new_payload.messages[1]["content"] == "repair context"
+
+    def test_apply_repair_result_with_text_append(self):
+        state = {}
+        payload = PromptPayload(text="original")
+        repair = RepairResult(prompt_text_append="additional context")
+        
+        new_state, new_payload = apply_repair_result(state, payload, repair)
+        
+        assert "original" in new_payload.text
+        assert "additional context" in new_payload.text
+
+
+class TestDefaultValidationRepair:
+    def test_default_repair_formats_validation_error(self):
+        try:
+            ExtractedUser(name="John", age="not a number")
+        except ValidationError as e:
+            ctx = RepairContext(
+                error=e,
+                state={},
+                prompt_payload=PromptPayload(text="test"),
+                response=LLMResponse(text='{"name": "John", "age": "not a number"}'),
+                attempt=1,
+                max_attempts=3,
+            )
+            result = default_validation_repair(ctx)
+            
+            assert result.messages_append is not None
+            assert len(result.messages_append) == 1
+            msg = result.messages_append[0]["content"]
+            assert "validation" in msg.lower() or "error" in msg.lower()
+            assert "age" in msg.lower()
+
+    def test_default_repair_formats_generic_error(self):
+        ctx = RepairContext(
+            error=ValueError("JSON parse failed"),
+            state={},
+            prompt_payload=PromptPayload(text="test"),
+            response=LLMResponse(text="not valid json"),
+            attempt=1,
+            max_attempts=3,
+        )
+        result = default_validation_repair(ctx)
+        
+        assert result.messages_append is not None
+        msg = result.messages_append[0]["content"]
+        assert "JSON parse failed" in msg
+        assert "not valid json" in msg
+
+
+class TestLLMRepairPolicy:
+    def test_policy_defaults(self):
+        policy = LLMRepairPolicy()
+        assert policy.max_attempts == 3
+        assert policy.backoff_seconds == 0.0
+        assert policy.backoff_multiplier == 2.0
+
+    def test_is_retryable_with_validation_error(self):
+        policy = LLMRepairPolicy()
+        try:
+            ExtractedUser(name="test", age="bad")
+        except ValidationError as e:
+            assert policy.is_retryable(e) is True
+
+    def test_is_retryable_with_custom_exceptions(self):
+        policy = LLMRepairPolicy(retryable_exceptions=(KeyError,))
+        assert policy.is_retryable(KeyError("test")) is True
+        assert policy.is_retryable(ValueError("test")) is False
+
+
+class TestValidatedLLMCall:
+    def test_success_on_first_attempt(self):
+        call_count = 0
+        
+        def llm_fn(state, payload):
+            nonlocal call_count
+            call_count += 1
+            return LLMResponse(text='{"name": "John", "age": 25}')
+        
+        def validator(response):
+            import json
+            data = json.loads(response.text)
+            return ExtractedUser.model_validate(data)
+        
+        result = validated_llm_call(
+            llm_fn=llm_fn,
+            prompt_payload=PromptPayload(text="extract user"),
+            state={},
+            validator=validator,
+            policy=LLMRepairPolicy(max_attempts=3),
+        )
+        
+        assert call_count == 1
+        assert result.name == "John"
+        assert result.age == 25
+
+    def test_success_after_repair(self):
+        call_count = 0
+        
+        def llm_fn(state, payload):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return LLMResponse(text='{"name": "John", "age": "twenty"}')
+            return LLMResponse(text='{"name": "John", "age": 25}')
+        
+        def validator(response):
+            import json
+            data = json.loads(response.text)
+            return ExtractedUser.model_validate(data)
+        
+        result = validated_llm_call(
+            llm_fn=llm_fn,
+            prompt_payload=PromptPayload(text="extract user"),
+            state={},
+            validator=validator,
+            policy=LLMRepairPolicy(max_attempts=3),
+        )
+        
+        assert call_count == 2
+        assert result.name == "John"
+        assert result.age == 25
+
+    def test_exhausts_attempts_and_raises(self):
+        call_count = 0
+        
+        def llm_fn(state, payload):
+            nonlocal call_count
+            call_count += 1
+            return LLMResponse(text='{"name": "John", "age": "invalid"}')
+        
+        def validator(response):
+            import json
+            data = json.loads(response.text)
+            return ExtractedUser.model_validate(data)
+        
+        with pytest.raises(LLMValidationError) as exc_info:
+            validated_llm_call(
+                llm_fn=llm_fn,
+                prompt_payload=PromptPayload(text="extract user"),
+                state={},
+                validator=validator,
+                policy=LLMRepairPolicy(max_attempts=3),
+            )
+        
+        assert call_count == 3
+        assert exc_info.value.attempts == 3
+        assert exc_info.value.last_response is not None
+        assert isinstance(exc_info.value.last_error, ValidationError)
+
+    def test_custom_repair_function_is_called(self):
+        repair_calls = []
+        
+        def custom_repair(ctx: RepairContext) -> RepairResult:
+            repair_calls.append(ctx.attempt)
+            return RepairResult(
+                messages_append=[{"role": "user", "content": f"Attempt {ctx.attempt} failed"}]
+            )
+        
+        call_count = 0
+        payloads_received = []
+        
+        def llm_fn(state, payload):
+            nonlocal call_count
+            call_count += 1
+            payloads_received.append(payload)
+            if call_count < 3:
+                return LLMResponse(text="bad")
+            return LLMResponse(text='{"name": "Jane", "age": 30}')
+        
+        def validator(response):
+            import json
+            data = json.loads(response.text)
+            return ExtractedUser.model_validate(data)
+        
+        policy = LLMRepairPolicy(max_attempts=3, failure_to_input=custom_repair)
+        
+        result = validated_llm_call(
+            llm_fn=llm_fn,
+            prompt_payload=PromptPayload(messages=[{"role": "user", "content": "extract"}]),
+            state={},
+            validator=validator,
+            policy=policy,
+        )
+        
+        assert repair_calls == [1, 2]
+        assert result.name == "Jane"
+        assert result.age == 30
+        assert len(payloads_received[2].messages) > len(payloads_received[0].messages)
+
+    def test_non_retryable_exception_raises_immediately(self):
+        call_count = 0
+        
+        def llm_fn(state, payload):
+            nonlocal call_count
+            call_count += 1
+            return LLMResponse(text="test")
+        
+        def validator(response):
+            raise RuntimeError("Not retryable")
+        
+        policy = LLMRepairPolicy(
+            max_attempts=3,
+            retryable_exceptions=(ValidationError,),
+        )
+        
+        with pytest.raises(RuntimeError, match="Not retryable"):
+            validated_llm_call(
+                llm_fn=llm_fn,
+                prompt_payload=PromptPayload(text="test"),
+                state={},
+                validator=validator,
+                policy=policy,
+            )
+        
+        assert call_count == 1
+
+
+class TestLLMValidationError:
+    def test_error_contains_all_context(self):
+        original = ValueError("parse failed")
+        response = LLMResponse(text="bad data")
+        
+        error = LLMValidationError(
+            "Validation failed",
+            last_error=original,
+            attempts=3,
+            last_response=response,
+        )
+        
+        assert error.last_error is original
+        assert error.attempts == 3
+        assert error.last_response is response
+        assert "Validation failed" in str(error)

--- a/tests/core/providers/test_claude_provider.py
+++ b/tests/core/providers/test_claude_provider.py
@@ -1,0 +1,153 @@
+from coevolved.core.providers import ClaudeProvider
+from coevolved.core.types import LLMConfig, LLMRequest, PromptPayload, ToolCall, ToolSpec
+
+
+class FakeTextBlock:
+    def __init__(self, text: str) -> None:
+        self.type = "text"
+        self.text = text
+
+
+class FakeToolUseBlock:
+    def __init__(self, tool_id: str, name: str, input_data) -> None:
+        self.type = "tool_use"
+        self.id = tool_id
+        self.name = name
+        self.input = input_data
+
+
+class FakeResponse:
+    def __init__(self, content, *, model: str, stop_reason: str, usage) -> None:
+        self.content = content
+        self.model = model
+        self.stop_reason = stop_reason
+        self.usage = usage
+
+
+class FakeStream:
+    def __init__(self, events) -> None:
+        self.events = events
+
+    def __iter__(self):
+        return iter(self.events)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class FakeMessages:
+    def __init__(self, response=None, stream=None) -> None:
+        self.response = response
+        self.stream = stream
+        self.last_params = None
+
+    def create(self, **params):
+        self.last_params = params
+        if params.get("stream"):
+            return self.stream
+        return self.response
+
+
+class FakeClient:
+    def __init__(self, response=None, stream=None) -> None:
+        self.messages = FakeMessages(response=response, stream=stream)
+
+
+def test_claude_complete_parses_text_and_tool_calls():
+    response = FakeResponse(
+        content=[
+            FakeTextBlock("Hello "),
+            FakeToolUseBlock("tool-1", "search", {"query": "docs"}),
+            FakeTextBlock("done"),
+        ],
+        model="claude-test",
+        stop_reason="tool_use",
+        usage={"input_tokens": 3, "output_tokens": 2},
+    )
+    client = FakeClient(response=response)
+    provider = ClaudeProvider(client)
+    tool_spec = ToolSpec(
+        name="search",
+        description="Search docs",
+        parameters={
+            "type": "object",
+            "properties": {"query": {"type": "string"}},
+            "required": ["query"],
+        },
+    )
+    request = LLMRequest(
+        prompt=PromptPayload(text="Hi"),
+        context=LLMConfig(
+            model="claude-test",
+            max_tokens=10,
+            tools=[tool_spec],
+            tool_choice="auto",
+        ),
+    )
+
+    result = provider.complete(request)
+
+    assert result.text == "Hello done"
+    assert result.tool_calls == [
+        ToolCall(id="tool-1", name="search", arguments={"query": "docs"})
+    ]
+    assert result.finish_reason == "tool_use"
+    assert result.usage == {"input_tokens": 3, "output_tokens": 2}
+
+    params = client.messages.last_params
+    assert params["messages"] == [{"role": "user", "content": "Hi"}]
+    assert params["tools"][0]["input_schema"] == tool_spec.parameters
+    assert params["tool_choice"] == {"type": "auto"}
+
+
+def test_claude_stream_emits_chunks_and_finish():
+    events = [
+        {
+            "type": "content_block_delta",
+            "index": 0,
+            "delta": {"type": "text_delta", "text": "Hello "},
+        },
+        {
+            "type": "content_block_start",
+            "index": 1,
+            "content_block": {
+                "type": "tool_use",
+                "id": "tool-1",
+                "name": "search",
+                "input": {},
+            },
+        },
+        {
+            "type": "content_block_delta",
+            "index": 1,
+            "delta": {"type": "input_json_delta", "partial_json": "{\"query\": \"docs\"}"},
+        },
+        {
+            "type": "message_delta",
+            "delta": {
+                "stop_reason": "tool_use",
+                "usage": {"input_tokens": 2, "output_tokens": 1},
+            },
+        },
+        {"type": "message_stop", "message": {"stop_reason": "tool_use"}},
+    ]
+    client = FakeClient(stream=FakeStream(events))
+    provider = ClaudeProvider(client)
+    request = LLMRequest(
+        prompt=PromptPayload(text="Hi"),
+        context=LLMConfig(model="claude-test", max_tokens=5),
+    )
+
+    chunks = list(provider.stream(request))
+
+    assert chunks[0].text == "Hello "
+    assert any(
+        chunk.tool_call_delta
+        and chunk.tool_call_delta.get("name") == "search"
+        for chunk in chunks
+    )
+    assert chunks[-1].finish_reason == "tool_use"
+    assert chunks[-1].usage == {"input_tokens": 2, "output_tokens": 1}

--- a/tests/prebuilt/test_llm_retry.py
+++ b/tests/prebuilt/test_llm_retry.py
@@ -1,0 +1,243 @@
+"""Tests for prebuilt LLM and agent retry utilities."""
+
+import pytest
+from pydantic import BaseModel
+
+from coevolved.base.step import Step
+from coevolved.core.llm_repair import LLMValidationError, RepairContext, RepairResult
+from coevolved.core.types import LLMResponse
+from coevolved.prebuilt.llm_retry import agent_retry, llm_retry
+
+
+class ExtractedData(BaseModel):
+    value: str
+    count: int
+
+
+def make_llm_step(responses: list, name: str = "test_llm"):
+    """Create a mock LLM step that returns responses in sequence."""
+    call_count = [0]
+    
+    def run(state):
+        idx = min(call_count[0], len(responses) - 1)
+        call_count[0] += 1
+        response = responses[idx]
+        if isinstance(state, dict):
+            return {**state, "llm_response": response}
+        return response
+    
+    return Step(run, name=name, annotations={"kind": "llm"})
+
+
+class TestLLMRetry:
+    def test_llm_retry_requires_llm_step(self):
+        regular_step = Step(lambda s: s, name="not_llm")
+        
+        with pytest.raises(ValueError, match="requires an LLM step"):
+            llm_retry(regular_step, output_schema=ExtractedData)
+
+    def test_success_on_first_attempt(self):
+        response = LLMResponse(text='{"value": "test", "count": 42}')
+        step = make_llm_step([response])
+        
+        wrapped = llm_retry(step, output_schema=ExtractedData)
+        result = wrapped({})
+        
+        assert "validated_output" in result
+        assert result["validated_output"].value == "test"
+        assert result["validated_output"].count == 42
+
+    def test_success_after_repair(self):
+        bad_response = LLMResponse(text='{"value": "test", "count": "not a number"}')
+        good_response = LLMResponse(text='{"value": "test", "count": 42}')
+        step = make_llm_step([bad_response, good_response])
+        
+        wrapped = llm_retry(step, output_schema=ExtractedData, max_attempts=3)
+        result = wrapped({"messages": []})
+        
+        assert result["validated_output"].count == 42
+
+    def test_exhausts_attempts_and_raises(self):
+        bad_response = LLMResponse(text='{"value": "test", "count": "invalid"}')
+        step = make_llm_step([bad_response, bad_response, bad_response])
+        
+        wrapped = llm_retry(step, output_schema=ExtractedData, max_attempts=3)
+        
+        with pytest.raises(LLMValidationError) as exc_info:
+            wrapped({})
+        
+        assert exc_info.value.attempts == 3
+
+    def test_custom_validator(self):
+        response = LLMResponse(text="custom format: test=42")
+        step = make_llm_step([response])
+        
+        def custom_validator(resp: LLMResponse) -> dict:
+            parts = resp.text.replace("custom format: ", "").split("=")
+            return {"key": parts[0], "val": int(parts[1])}
+        
+        wrapped = llm_retry(step, validator=custom_validator)
+        result = wrapped({})
+        
+        assert result["validated_output"] == {"key": "test", "val": 42}
+
+    def test_custom_repair_function(self):
+        repair_calls = []
+        
+        def my_repair(ctx: RepairContext) -> RepairResult:
+            repair_calls.append(ctx.attempt)
+            return RepairResult(
+                state_updates={"hint": f"retry {ctx.attempt}"}
+            )
+        
+        bad_response = LLMResponse(text="bad")
+        good_response = LLMResponse(text='{"value": "ok", "count": 1}')
+        step = make_llm_step([bad_response, good_response])
+        
+        wrapped = llm_retry(
+            step,
+            output_schema=ExtractedData,
+            failure_to_input=my_repair,
+        )
+        result = wrapped({})
+        
+        assert len(repair_calls) == 1
+        assert result["validated_output"].value == "ok"
+
+    def test_result_key_none_returns_directly(self):
+        response = LLMResponse(text='{"value": "direct", "count": 99}')
+        step = make_llm_step([response])
+        
+        wrapped = llm_retry(step, output_schema=ExtractedData, result_key=None)
+        result = wrapped({})
+        
+        assert isinstance(result, ExtractedData)
+        assert result.value == "direct"
+
+    def test_handles_json_with_markdown_fences(self):
+        response = LLMResponse(text='```json\n{"value": "fenced", "count": 5}\n```')
+        step = make_llm_step([response])
+        
+        wrapped = llm_retry(step, output_schema=ExtractedData)
+        result = wrapped({})
+        
+        assert result["validated_output"].value == "fenced"
+
+    def test_step_annotations_preserved(self):
+        step = make_llm_step([LLMResponse(text="{}")])
+        step.annotations["custom"] = "value"
+        
+        wrapped = llm_retry(step, max_attempts=5)
+        
+        assert wrapped.annotations["custom"] == "value"
+        assert wrapped.annotations["retry_wrapper"] is True
+        assert wrapped.annotations["max_attempts"] == 5
+
+
+class TestAgentRetry:
+    def test_success_on_first_attempt(self):
+        step = Step(lambda s: {**s, "result": "done"}, name="agent")
+        
+        wrapped = agent_retry(step, max_attempts=3)
+        result = wrapped({"input": "test"})
+        
+        assert result["result"] == "done"
+
+    def test_retries_on_failure_then_succeeds(self):
+        call_count = [0]
+        
+        def run(state):
+            call_count[0] += 1
+            if call_count[0] < 3:
+                raise ValueError("temporary failure")
+            return {**state, "result": "success"}
+        
+        step = Step(run, name="flaky_agent")
+        wrapped = agent_retry(step, max_attempts=3)
+        result = wrapped({})
+        
+        assert call_count[0] == 3
+        assert result["result"] == "success"
+
+    def test_exhausts_attempts_and_raises(self):
+        def run(state):
+            raise ValueError("always fails")
+        
+        step = Step(run, name="failing_agent")
+        wrapped = agent_retry(step, max_attempts=3)
+        
+        with pytest.raises(ValueError, match="always fails"):
+            wrapped({})
+
+    def test_custom_should_retry_predicate(self):
+        call_count = [0]
+        
+        def run(state):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                raise TimeoutError("timed out")
+            raise ValueError("different error")
+        
+        def only_retry_timeout(exc, state, attempt):
+            return isinstance(exc, TimeoutError)
+        
+        step = Step(run, name="agent")
+        wrapped = agent_retry(step, max_attempts=3, should_retry=only_retry_timeout)
+        
+        with pytest.raises(ValueError, match="different error"):
+            wrapped({})
+        
+        assert call_count[0] == 2
+
+    def test_on_retry_callback_modifies_state(self):
+        call_count = [0]
+        states_seen = []
+        
+        def run(state):
+            call_count[0] += 1
+            states_seen.append(state.copy())
+            if call_count[0] < 3:
+                raise ValueError("retry")
+            return state
+        
+        def on_retry(exc, state, attempt):
+            return {**state, "retry_count": attempt}
+        
+        step = Step(run, name="agent")
+        wrapped = agent_retry(step, max_attempts=3, on_retry=on_retry)
+        result = wrapped({"initial": True})
+        
+        assert states_seen[0] == {"initial": True}
+        assert states_seen[1] == {"initial": True, "retry_count": 1}
+        assert states_seen[2] == {"initial": True, "retry_count": 2}
+
+    def test_on_retry_callback_returning_none_keeps_state(self):
+        call_count = [0]
+        callback_called = [False]
+        
+        def run(state):
+            call_count[0] += 1
+            if call_count[0] < 2:
+                raise ValueError("retry")
+            return state
+        
+        def on_retry(exc, state, attempt):
+            callback_called[0] = True
+            return None
+        
+        step = Step(run, name="agent")
+        wrapped = agent_retry(step, max_attempts=3, on_retry=on_retry)
+        result = wrapped({"value": 1})
+        
+        assert callback_called[0] is True
+        assert result == {"value": 1}
+
+    def test_step_annotations_include_retry_info(self):
+        step = Step(lambda s: s, name="agent", annotations={"kind": "agent"})
+        
+        wrapped = agent_retry(step, max_attempts=5)
+        
+        assert wrapped.annotations["kind"] == "agent"
+        assert wrapped.annotations["agent_retry_wrapper"] is True
+        assert wrapped.annotations["max_attempts"] == 5
+        assert wrapped.name == "agent_retry"


### PR DESCRIPTION
This PR completes the implementation of:

- **Claude/Anthropic Provider**: New provider with PromptPayload coercion (including system aggregation), ToolSpec→Claude tools mapping, tool_use parsing into ToolCall, and streaming event handling.
- **OpenAI Parity**: Tightened tool_choice normalization and streaming tool-call delta parity.
- **LLM Repair/Validation**: Core logic in `src/coevolved/core/llm_repair.py` including `LLMRepairPolicy`, `RepairContext`, and `validated_llm_call`.
- **Prebuilt Retry Helpers**: `llm_retry` and `agent_retry` in `src/coevolved/prebuilt/llm_retry.py`.
- **Tests**: Unit tests for Claude provider, LLM repair, and retry logic.
- **Documentation**: New docs for LLM validation and retry.
- **Exports**: Wired exports in `core` and `prebuilt` levels.
- **Extras**: Added `anthropic` optional dependency in `pyproject.toml`.

---
*If you like my work, please contact me at [dekai.me](https://dekai.me).* 